### PR TITLE
feat: use ubuntu to run cryptography and be compliant with other iMio apps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -78,7 +78,7 @@ RUN curl -L https://github.com/Yelp/dumb-init/releases/download/v1.2.5/dumb-init
 
 LABEL plone=$PLONE_VERSION \
   os="Ubuntu" \
-  os.version="22.04" \
+  os.version="20.04" \
   name="Plone 5.2.5" \
   description="Plone image for imioweb app on iA.Smartweb project" \
   maintainer="iMio"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM harbor.imio.be/common/base:py3-ubuntu-20.04 as builder
+FROM imiobe/base:py3-ubuntu-20.04 as builder
 ENV PIP=19.3.1 \
   ZC_BUILDOUT=2.13.2 \
   SETUPTOOLS=45.0.0 \
@@ -36,7 +36,7 @@ COPY --chown=imio scripts /plone/scripts
 RUN su -c "buildout -c prod.cfg -t 30" -s /bin/sh imio
 
 
-FROM harbor.imio.be/common/base:py3-ubuntu-20.04
+FROM imiobe/base:py3-ubuntu-20.04
 
 ENV PIP=19.3.1 \
   ZC_BUILDOUT=2.13.2 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM imiobe/base:py3-alpine as builder
+FROM harbor.imio.be/common/base:py3-ubuntu-20.04 as builder
 ENV PIP=19.3.1 \
   ZC_BUILDOUT=2.13.2 \
   SETUPTOOLS=45.0.0 \
@@ -6,22 +6,28 @@ ENV PIP=19.3.1 \
   PLONE_MAJOR=5.2 \
   PLONE_VERSION=5.2.1
 
-RUN apk add --update --no-cache --virtual .build-deps \
-  build-base \
+# hadolint ignore=DL3008
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  build-essential \
   gcc \
   git \
-  libc-dev \
+  libbz2-dev \
+  libc6-dev \
   libffi-dev \
-  libjpeg-turbo-dev \
-  libpng-dev \
-  libwebp-dev \
+  libjpeg62-dev \
+  libopenjp2-7-dev \
+  libmemcached-dev \
+  libpcre3-dev \
+  libpq-dev \
+  libreadline-dev \
+  libssl-dev \
   libxml2-dev \
-  libxslt-dev \
-  openssl-dev \
-  pcre-dev \
+  libxslt1-dev \
+  python3-dev \
+  python3-pip \
   wget \
-  zlib-dev \
-  && pip install pip==$PIP setuptools==$SETUPTOOLS zc.buildout==$ZC_BUILDOUT wheel==$WHEEL
+  zlib1g-dev \
+  && pip3 install --no-cache-dir pip==$PIP setuptools==$SETUPTOOLS zc.buildout==$ZC_BUILDOUT py-spy
 WORKDIR /plone
 RUN chown imio:imio -R /plone && mkdir /data && chown imio:imio -R /data
 #COPY --chown=imio eggs /plone/eggs/
@@ -30,7 +36,7 @@ COPY --chown=imio scripts /plone/scripts
 RUN su -c "buildout -c prod.cfg -t 30" -s /bin/sh imio
 
 
-FROM imiobe/base:py3-alpine
+FROM harbor.imio.be/common/base:py3-ubuntu-20.04
 
 ENV PIP=19.3.1 \
   ZC_BUILDOUT=2.13.2 \
@@ -49,25 +55,35 @@ VOLUME /data/blobstorage
 VOLUME /data/filestorage
 WORKDIR /plone
 
-RUN apk add --no-cache --virtual .run-deps \
-  bash \
-  rsync \
+# hadolint ignore=DL3008
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  curl \
+  libjpeg62 \
+  libmemcached11 \
+  libopenjp2-7 \
+  libpq5 \
+  libtiff5 \
   libxml2 \
-  libxslt \
-  libpng \
-  libjpeg-turbo \
+  libxslt1.1 \
   lynx \
+  netcat \
   poppler-utils \
-  wv
+  python3-distutils \
+  rsync \
+  wget \
+  wv \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+RUN curl -L https://github.com/Yelp/dumb-init/releases/download/v1.2.5/dumb-init_1.2.5_amd64.deb > /tmp/dumb-init.deb && dpkg -i /tmp/dumb-init.deb && rm /tmp/dumb-init.deb
 
 LABEL plone=$PLONE_VERSION \
-  os="alpine" \
-  os.version="3.10" \
+  os="Ubuntu" \
+  os.version="22.04" \
   name="Plone 5.2.5" \
   description="Plone image for imioweb app on iA.Smartweb project" \
-  maintainer="Imio"
+  maintainer="iMio"
 
-COPY --from=builder /usr/local/lib/python3.8/site-packages /usr/local/lib/python3.8/site-packages
+COPY --from=builder /usr/local/lib/python3.8/dist-packages /usr/local/lib/python3.8/dist-packages
 COPY --chown=imio --from=builder /plone .
 RUN chown imio:imio /plone
 # DEBUG tools

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/dumb-init /bin/bash
 set -e
 COMMANDS="debug help logtail show stop adduser fg kill quit run wait console foreground logreopen reload shell status"
 START="start restart zeoserver"


### PR DESCRIPTION
I use ubuntu 20.04 because Zope 4.6.3 is not compatible with python 3.10 and so, default python for ubuntu 22.04